### PR TITLE
Update Msg to Message in server_linux.cpp

### DIFF
--- a/src/SmartXm-CSEKU/networking/server/server_linux.cpp
+++ b/src/SmartXm-CSEKU/networking/server/server_linux.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <cstring>
 #include "networking/FileMeta.h"
-#include "Msg.h"
+#include "Message.h"
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -186,7 +186,7 @@ void Server::acceptLoop() { // accept new connections
 }
 
 void Server::handleClient(int client_socket) { // after client is accepted, this needs
-    Msg msg;
+    Message msg;
     while (running) {
     // while (serverInstance != nullptr) {
         ssize_t valread = recv(client_socket, &msg, sizeof(msg), 0);


### PR DESCRIPTION
Replaces usage and inclusion of 'Msg' with 'Message' in server_linux.cpp to reflect updated class naming. Ensures consistency with the correct header and type.